### PR TITLE
Neue Komfort-Features: Pfad-Memory, Stop-Button, Alle-an/aus, Speicher-Check, Log-Export

### DIFF
--- a/Build/skript.ps1
+++ b/Build/skript.ps1
@@ -19,7 +19,7 @@ public static extern bool ShowWindow(IntPtr hWnd, Int32 nCmdShow);
 $consolePtr = [Console.Window]::GetConsoleWindow()
 [Console.Window]::ShowWindow($consolePtr, 0) | Out-Null
 
-$script:VersionString = "0.8.0" 
+$script:VersionString = "0.9.0"
 $script:BuildString = "GUI-Edition"
 $WindowTitle = "Windows DaSi Tool $script:VersionString"
 
@@ -247,7 +247,14 @@ $Xaml = @"
 
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
-                    <TextBlock Style="{StaticResource SectionLabel}" Text="SICHERN (Backup)"/>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource SectionLabel}" Text="SICHERN (Backup)"/>
+                        <Button Name="BtnAllBackup" Grid.Column="1" Style="{StaticResource SecondaryBtn}" Content="Alle an/aus" Width="100" Height="28" VerticalAlignment="Bottom" Margin="4,0,4,2"/>
+                    </Grid>
                     <UniformGrid Columns="2">
                         <ToggleButton Name="TgB_User" Style="{StaticResource CardToggle}" Content="Windows Benutzerprofil"/>
                         <ToggleButton Name="TgB_Firefox" Style="{StaticResource CardToggle}" Content="Firefox-Profil"/>
@@ -259,7 +266,14 @@ $Xaml = @"
                         <ToggleButton Name="TgB_Wlan" Style="{StaticResource CardToggle}" Content="WLAN Profile exportieren"/>
                     </UniformGrid>
 
-                    <TextBlock Style="{StaticResource SectionLabel}" Text="WIEDERHERSTELLEN (Restore)"/>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Style="{StaticResource SectionLabel}" Text="WIEDERHERSTELLEN (Restore)"/>
+                        <Button Name="BtnAllRestore" Grid.Column="1" Style="{StaticResource SecondaryBtn}" Content="Alle an/aus" Width="100" Height="28" VerticalAlignment="Bottom" Margin="4,0,4,2"/>
+                    </Grid>
                     <UniformGrid Columns="2">
                         <ToggleButton Name="TgR_User" Style="{StaticResource CardToggle}" Content="Windows Benutzerprofil"/>
                         <ToggleButton Name="TgR_Firefox" Style="{StaticResource CardToggle}" Content="Firefox-Profil"/>
@@ -273,7 +287,14 @@ $Xaml = @"
                 </StackPanel>
             </ScrollViewer>
 
-            <Button Name="BtnExecute" Grid.Row="2" Style="{StaticResource ActionBtn}" Content="Ausgew&#228;hlte Aktionen starten"/>
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Button Name="BtnExecute" Style="{StaticResource ActionBtn}" Content="Ausgew&#228;hlte Aktionen starten"/>
+                <Button Name="BtnStop" Grid.Column="1" Style="{StaticResource ExitBtn}" Content="Stoppen" Width="130" Margin="4,10,4,4"/>
+            </Grid>
         </Grid>
 
         <Grid Grid.Column="1">
@@ -309,7 +330,7 @@ function FillDataContext ($props) {
         $State | Add-Member -Name $props[$i] -MemberType ScriptProperty -Value $getter -SecondValue $setter
     }
 }
-FillDataContext @("LogText", "UIEnabled", "SourcePath", "BackupPath")
+FillDataContext @("LogText", "UIEnabled", "SourcePath", "BackupPath", "IsRunning")
 $Window.DataContext = $DataContext
 
 # Log-Text ohne Umlaute
@@ -317,6 +338,28 @@ $State.LogText = "Warte auf Eingabe...`nBitte waehle zuerst die benoetigten Pfad
 $State.UIEnabled = $true
 $State.SourcePath = ""
 $State.BackupPath = ""
+$State.IsRunning = $false
+
+#----Konfiguration: zuletzt verwendete Pfade merken------------#
+$script:ConfigDir  = Join-Path $env:APPDATA "WindowsDaSiTool"
+$script:ConfigFile = Join-Path $script:ConfigDir "config.json"
+
+function Save-AppConfig {
+    try {
+        if (-not (Test-Path $script:ConfigDir)) { New-Item -ItemType Directory -Path $script:ConfigDir -Force | Out-Null }
+        [pscustomobject]@{ SourcePath = $State.SourcePath; BackupPath = $State.BackupPath } |
+            ConvertTo-Json | Set-Content -Path $script:ConfigFile -Encoding UTF8
+    } catch {}
+}
+
+if (Test-Path $script:ConfigFile) {
+    try {
+        $cfg = Get-Content $script:ConfigFile -Raw -ErrorAction Stop | ConvertFrom-Json
+        if ($cfg.SourcePath -and (Test-Path $cfg.SourcePath)) { $State.SourcePath = $cfg.SourcePath }
+        if ($cfg.BackupPath -and (Test-Path $cfg.BackupPath)) { $State.BackupPath = $cfg.BackupPath }
+        if ($State.SourcePath -or $State.BackupPath) { $State.LogText += ">> Zuletzt verwendete Pfade geladen.`r`n" }
+    } catch {}
+}
 
 function Set-Binding {
     param($Target, $Property, $Index)
@@ -333,14 +376,18 @@ Set-Binding $TbBackupPath ([System.Windows.Controls.TextBox]::TextProperty) 3
 $ToggleButtons = @(
     "TgB_User","TgB_Firefox","TgB_Edge","TgB_Chrome","TgB_Brave","TgB_Thunderbird","TgB_Winget","TgB_Wlan",
     "TgR_User","TgR_Firefox","TgR_Edge","TgR_Chrome","TgR_Brave","TgR_Thunderbird","TgR_Winget","TgR_Wlan",
-    "BtnSelSource", "BtnSelBackup", "BtnClearPaths", "TgB_Logging", "BtnExecute"
+    "BtnSelSource", "BtnSelBackup", "BtnClearPaths", "TgB_Logging",
+    "BtnAllBackup", "BtnAllRestore", "BtnExecute"
 )
 foreach ($btn in $ToggleButtons) {
     $ctrl = $Window.FindName($btn)
     if ($ctrl) { Set-Binding $ctrl ([System.Windows.Controls.Control]::IsEnabledProperty) 1 }
 }
 
-#----Event Handler für UI & Pfade-----------------------#
+# Stop-Button ist nur AKTIV, waehrend ein Vorgang laeuft (Index 4 = IsRunning)
+Set-Binding $BtnStop ([System.Windows.Controls.Control]::IsEnabledProperty) 4
+
+#----Event Handler fï¿½r UI & Pfade-----------------------#
 
 $TgB_Logging.Add_Click({
     if ($TgB_Logging.IsChecked) { $TgB_Logging.Content = "Logging: Detailliert / AN" } 
@@ -351,17 +398,18 @@ $BtnClearPaths.Add_Click({
     $State.SourcePath = ""
     $State.BackupPath = ""
     $State.LogText += ">> Pfade wurden geleert.`r`n"
+    Save-AppConfig
 })
 
 $BtnSelSource.Add_Click({
     $folder = Select-FolderDialog -Description "Quell-Benutzerprofil auswaehlen (z.B. C:\Users\Name)"
-    if ($folder) { $State.SourcePath = $folder }
+    if ($folder) { $State.SourcePath = $folder; Save-AppConfig }
 })
 
 $BtnSelBackup.Add_Click({
     $folder = Select-FolderDialog -Description "Backup Basis-Verzeichnis auswaehlen"
     if ($folder) {
-        if (Test-IsNtfsDrive -Path $folder) { $State.BackupPath = $folder } 
+        if (Test-IsNtfsDrive -Path $folder) { $State.BackupPath = $folder; Save-AppConfig }
         else { [System.Windows.MessageBox]::Show("Das ausgewaehlte Laufwerk ist NICHT mit NTFS formatiert!`nRobocopy benoetigt zwingend NTFS.", "Fehler", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error) }
     }
 })
@@ -383,7 +431,31 @@ $Window.Add_Closing({
 
 $BtnExit.Add_Click({ $Window.Close() })
 
-#----Ausführungs-Logik (Runspace / Async) & Prozess-Tracking--#
+# "Alle an/aus": alle Toggles einer Sektion gemeinsam setzen
+$BtnAllBackup.Add_Click({
+    $list = @($TgB_User, $TgB_Firefox, $TgB_Edge, $TgB_Chrome, $TgB_Brave, $TgB_Thunderbird, $TgB_Winget, $TgB_Wlan)
+    $new = [bool]($list | Where-Object { -not $_.IsChecked })  # wenn irgendeiner aus ist -> alle an, sonst alle aus
+    foreach ($t in $list) { $t.IsChecked = $new }
+})
+
+$BtnAllRestore.Add_Click({
+    $list = @($TgR_User, $TgR_Firefox, $TgR_Edge, $TgR_Chrome, $TgR_Brave, $TgR_Thunderbird, $TgR_Winget, $TgR_Wlan)
+    $new = [bool]($list | Where-Object { -not $_.IsChecked })
+    foreach ($t in $list) { $t.IsChecked = $new }
+})
+
+# Stop-Button: laufenden Vorgang sauber abbrechen (ohne Fenster zu schliessen)
+$BtnStop.Add_Click({
+    if (-not $State.IsRunning) { return }
+    $SyncHash.CancelRequested = $true
+    $State.LogText += ">> Abbruch angefordert, laufende Prozesse werden beendet...`r`n"
+    foreach ($procId in $SyncHash.ActiveProcesses.ToArray()) {
+        Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    }
+    Stop-Process -Name winget -Force -ErrorAction SilentlyContinue
+})
+
+#----Ausfï¿½hrungs-Logik (Runspace / Async) & Prozess-Tracking--#
 $Global:SyncHash = [hashtable]::Synchronized(@{})
 $SyncHash.Window = $Window
 $SyncHash.ActiveProcesses = [System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList]::new())
@@ -427,11 +499,12 @@ function Run-Async ($scriptBlock) {
     )
 }
 
-# --- Originale Skript-Funktionen für den Runspace ---
+# --- Originale Skript-Funktionen fï¿½r den Runspace ---
 $RunspaceFunctionsCode = @'
 
-function Write-Log ($Text) { 
-    $State.LogText += "$Text`r`n" 
+function Write-Log ($Text) {
+    $State.LogText += "$Text`r`n"
+    if ($Text -like "*[FEHLER]*") { $SyncHash.ErrorCount = [int]$SyncHash.ErrorCount + 1 }
     if ($State.LogText.Length -gt 100000) {
         $State.LogText = "... [LOG GEKUERZT, UM ABSTURZ ZU VERHINDERN] ...`r`n" + $State.LogText.Substring($State.LogText.Length - 80000)
     }
@@ -716,7 +789,7 @@ function Import-WlanProfiles {
 }
 '@
 
-# Event für den "Ausführen" Button
+# Event fï¿½r den "Ausfï¿½hren" Button
 $BtnExecute.Add_Click({
     $TaskList = @()
     if ($TgB_User.IsChecked)        { $TaskList += "1" }
@@ -750,14 +823,26 @@ $BtnExecute.Add_Click({
     $SyncHash.FastMode = -not $TgB_Logging.IsChecked
     $SyncHash.TaskList = $TaskList
     $SyncHash.CancelRequested = $false
+    $SyncHash.ErrorCount = 0
+    $SyncHash.StartTime = Get-Date
 
     $State.UIEnabled = $false
+    $State.IsRunning = $true
     $State.LogText += "`n=========================================`n"
     $State.LogText += "Starte Abarbeitung der Warteschlange...`n"
-    
+
     # Runspace starten
     Run-Async {
         . ([ScriptBlock]::Create($SyncHash.RunspaceFunctionsCode))
+
+        # Freien Speicherplatz auf dem Ziel-Laufwerk pruefen
+        try {
+            $rootPath = [System.IO.Path]::GetPathRoot($State.BackupPath)
+            $di = [System.IO.DriveInfo]::new($rootPath)
+            $freeGB = [math]::Round($di.AvailableFreeSpace / 1GB, 1)
+            Write-Log "[INFO] Freier Speicher auf Ziel ($rootPath): $freeGB GB"
+            if ($freeGB -lt 1) { Write-Log "[WARNUNG] Sehr wenig freier Speicher auf dem Ziel-Laufwerk - Backup koennte fehlschlagen!" }
+        } catch {}
 
         foreach ($choice in $SyncHash.TaskList) {
             if ($SyncHash.CancelRequested) { 
@@ -789,13 +874,31 @@ $BtnExecute.Add_Click({
             Start-Sleep -Seconds 1
         }
         
+        # Abschluss-Zusammenfassung
+        $dauer = [int]((Get-Date) - $SyncHash.StartTime).TotalSeconds
+        $fehler = [int]$SyncHash.ErrorCount
         Write-Log "`n========================================="
+        Write-Log "Dauer: $dauer Sekunden  |  Fehler: $fehler"
         if ($SyncHash.CancelRequested) {
-            Write-Log "Tool sicher beendet."
+            Write-Log "Vorgang abgebrochen - Tool sicher beendet."
+        } elseif ($fehler -eq 0) {
+            Write-Log "Alle ausgewaehlten Aktionen erfolgreich abgeschlossen!"
         } else {
-            Write-Log "Alle ausgewaehlten Aktionen abgeschlossen!"
-            $State.UIEnabled = $true
+            Write-Log "Abgeschlossen, aber mit $fehler Fehler(n) - bitte Protokoll pruefen."
         }
+
+        # Protokoll automatisch als Datei sichern
+        try {
+            if ($State.BackupPath -and (Test-Path $State.BackupPath)) {
+                $logFile = Join-Path $State.BackupPath ("DaSi-Log_" + (Get-Date -Format "yyyyMMdd_HHmmss") + ".txt")
+                $State.LogText | Out-File -FilePath $logFile -Encoding UTF8 -ErrorAction Stop
+                Write-Log "[INFO] Protokoll gespeichert: $logFile"
+            }
+        } catch { Write-Log "[WARNUNG] Protokoll konnte nicht gespeichert werden." }
+
+        # UI in jedem Fall wieder freigeben
+        $State.IsRunning = $false
+        $State.UIEnabled = $true
     }
 })
 
@@ -803,7 +906,7 @@ $SyncHash.RunspaceFunctionsCode = $RunspaceFunctionsCode
 
 Start-RunspaceTask $JobCleanupScript @([psobject]@{ Name = 'Jobs'; Variable = $Jobs })
 
-$Window.Add_Closed({ $SyncHash.CleanupJobs = $false })
+$Window.Add_Closed({ $SyncHash.CleanupJobs = $false; Save-AppConfig })
 $SyncHash.CleanupJobs = $true
 
 # Fenster anzeigen

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ Entwickelt für IT-Administratoren und Power-User – vereint die Robustheit von
 
 ---
 
+## ✨ Neu: Komfort-Features
+
+| Feature | Nutzen |
+|---|---|
+| **Pfade werden gemerkt** | Quell- und Backup-Verzeichnis werden in `%APPDATA%\WindowsDaSiTool\config.json` gespeichert und beim nächsten Start automatisch geladen – kein erneutes Auswählen nötig. |
+| **„Alle an/aus"-Buttons** | Pro Sektion (Sichern / Wiederherstellen) lassen sich alle Häkchen mit einem Klick setzen oder entfernen. |
+| **Stop-Button** | Ein laufender Vorgang kann jetzt direkt über einen Button abgebrochen werden, ohne das Fenster zu schließen. Der Button ist nur aktiv, solange etwas läuft. |
+| **Speicherplatz-Prüfung** | Vor dem Lauf wird der freie Speicher auf dem Ziel-Laufwerk angezeigt und bei wenig Platz gewarnt. |
+| **Abschluss-Zusammenfassung** | Am Ende werden Dauer und Anzahl der Fehler ausgegeben. |
+| **Protokoll als Datei** | Nach jedem Lauf wird das komplette Protokoll als `DaSi-Log_<Zeitstempel>.txt` im Backup-Ziel gespeichert. |
+| **UI-Fix** | Nach einem Abbruch wird die Oberfläche zuverlässig wieder freigegeben (vorher konnte sie gesperrt bleiben). |
+
+---
+
 ## 🛡️ Systemanforderungen
 
 | Anforderung | Details |


### PR DESCRIPTION
Hallo nochmal! 👋 Dieser PR ergänzt das Tool um mehrere **Komfort-Features**. Er ist **unabhängig** von meinem anderen PR (Bugfixes) – beide gehen sauber von `main` aus und können in beliebiger Reihenfolge gemergt werden. Alle Änderungen sind reine PowerShell-/XAML-Anpassungen in `Build/skript.ps1` (+ README). Geprüft: beide Skript-Blöcke parsen fehlerfrei und das XAML lädt mit allen Controls.

## Neue Features

- 💾 **Pfade werden gemerkt** – Quell-/Backup-Verzeichnis landen in `%APPDATA%\WindowsDaSiTool\config.json` und werden beim Start automatisch geladen.
- ☑️ **„Alle an/aus"-Buttons** – pro Sektion (Sichern / Wiederherstellen) alle Häkchen mit einem Klick setzen oder entfernen.
- ⏹️ **Stop-Button in der UI** – laufenden Vorgang abbrechen, ohne das Fenster zu schließen. Nur aktiv, solange wirklich etwas läuft (neuer `IsRunning`-State).
- 📊 **Speicherplatz-Prüfung** – freier Platz auf dem Ziel-Laufwerk wird vor dem Lauf angezeigt, Warnung bei wenig Platz.
- 🧾 **Abschluss-Zusammenfassung** – Dauer + Anzahl Fehler am Ende des Laufs.
- 📄 **Protokoll als Datei** – nach jedem Lauf `DaSi-Log_<Zeitstempel>.txt` im Backup-Ziel.
- 🔧 **UI-Fix** – nach einem Abbruch wird die Oberfläche zuverlässig wieder freigegeben (vorher konnte sie gesperrt bleiben).

## Hinweis
Versionsnummer ist hier auf `0.9.0` gesetzt – falls auch mein Bugfix-PR gemergt wird, einfach beim Zusammenführen eine gemeinsame Versionsnummer wählen. Die `.exe` müsste per PS2EXE (`Build/ps1zuexe.txt`) neu gebaut werden.

Kein Zwang das komplett zu mergen – nimm gern nur die Teile, die dir gefallen. 🙂

🤖 Generated with [Claude Code](https://claude.com/claude-code)